### PR TITLE
[#45] [Chore] Remove babel's dependencies warning in CI

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "plugins": [["@babel/plugin-proposal-private-property-in-object", { "loose": true }]]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,10 @@
         "sass": "1.49.11"
       },
       "devDependencies": {
-        "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
+        "@babel/core": "7.22.5",
+        "@babel/eslint-parser": "7.22.5",
+        "@babel/plugin-proposal-private-property-in-object": "7.21.11",
+        "@babel/preset-env": "7.22.5",
         "@cypress/browserify-preprocessor": "3.0.2",
         "@cypress/code-coverage": "3.10.7",
         "@cypress/instrument-cra": "1.4.0",
@@ -627,9 +630,16 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       },
@@ -1872,6 +1882,17 @@
         "core-js-compat": "^3.30.2",
         "semver": "^6.3.0"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
       "engines": {
         "node": ">=6.9.0"
       },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,10 @@
     ]
   },
   "devDependencies": {
-    "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
+    "@babel/core": "7.22.5",
+    "@babel/eslint-parser": "7.22.5",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11",
+    "@babel/preset-env": "7.22.5",
     "@cypress/browserify-preprocessor": "3.0.2",
     "@cypress/code-coverage": "3.10.7",
     "@cypress/instrument-cra": "1.4.0",


### PR DESCRIPTION
Close #45 

## What happened 👀

- Add the babel's dependencies to remove the warning in CI.

## Insight 📝

- We have to add all babel's dependencies instead of 1 mentioned dependency `@babel/plugin-proposal-private-property-in-object`: [Ref](https://stackoverflow.com/a/76441528). Thanks @tyrro for the suggestion 🚀 

## Proof Of Work 📹

<img width="1259" alt="image" src="https://github.com/manh-t/react-survey/assets/60863885/b6cbcd5f-eced-4373-9c9c-ccb08eda9397">

