### PR TITLE
[#17] [Integrate] As a user, I can keep using the application after the sign in token expired

### DIFF
--- a/src/lib/request/v1/requestManager.ts
+++ b/src/lib/request/v1/requestManager.ts
@@ -2,6 +2,7 @@ import axios, { Method as HTTPMethod, ResponseType, AxiosRequestConfig, AxiosRes
 
 import { config } from 'config';
 import { JSONValue, keysToCamelCase } from 'helpers/json';
+import { refreshToken } from 'services/refreshToken';
 
 export const successResponseInterceptor = (response: AxiosResponse<unknown>): AxiosResponse<unknown> => {
   const responseData = response.data as JSONValue;
@@ -13,6 +14,9 @@ export const successResponseInterceptor = (response: AxiosResponse<unknown>): Ax
 
 export const errorInterceptor = async (error: AxiosError<unknown>): Promise<unknown> => {
   if (error.response) {
+    if (error.response.status === 401) {
+      return refreshToken(error);
+    }
     const errorData = error.response.data as JSONValue;
     const formattedData = keysToCamelCase(errorData);
     error.response.data = formattedData;

--- a/src/services/refreshToken.test.ts
+++ b/src/services/refreshToken.test.ts
@@ -111,7 +111,7 @@ describe('refreshToken', () => {
         tokenType: 'tokenType',
       }));
 
-      global.window = Object.create(window);
+      global.window ??= Object.create(window);
       const url = 'http://dummy.com';
       Object.defineProperty(window, 'location', {
         value: {

--- a/src/services/refreshToken.test.ts
+++ b/src/services/refreshToken.test.ts
@@ -1,0 +1,157 @@
+import { AxiosError } from 'axios';
+
+import { refreshToken as authenticationRefreshToken } from 'adapters/Authentication';
+import { clearToken, getToken, setToken } from 'helpers/authentication';
+import { paths } from 'routes';
+
+import { refreshToken } from './refreshToken';
+
+jest.mock('helpers/authentication');
+jest.mock('adapters/Authentication');
+
+jest.mock('axios', () => jest.fn(() => Promise.resolve()));
+
+const axiosHeaders = new (jest.requireActual('axios').AxiosHeaders)();
+
+describe('refreshToken', () => {
+  describe('given the refresh token API is fetched successfully', () => {
+    beforeEach(() => {
+      (authenticationRefreshToken as jest.Mock).mockImplementation(() =>
+        Promise.resolve({
+          data: {
+            id: 'id',
+            type: 'type',
+            attributes: {
+              accessToken: 'access token',
+              tokenType: 'token type',
+              refreshToken: 'refresh token',
+            },
+          },
+          status: 200,
+          statusText: 'OK',
+          headers: axiosHeaders,
+          config: {},
+        })
+      );
+      (getToken as jest.Mock).mockImplementation(() => ({
+        id: 'resourceId',
+        type: 'resourceType',
+        accessToken: 'accessToken',
+        refreshToken: 'refreshToken',
+        tokenType: 'tokenType',
+      }));
+
+      (setToken as jest.Mock).mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('appends the Authorization header successfully', async () => {
+      const mockError: AxiosError<unknown> = {
+        isAxiosError: true,
+        name: '',
+        message: '',
+        toJSON: () => ({}),
+        config: {
+          headers: axiosHeaders,
+        },
+        response: {
+          data: {
+            errors: [],
+          },
+          status: 401,
+          statusText: 'OK',
+          headers: {},
+          config: {
+            headers: axiosHeaders,
+          },
+        },
+      };
+
+      expect(mockError.config?.headers.Authorization).toBeUndefined();
+
+      await refreshToken(mockError);
+
+      expect(mockError.config?.headers.Authorization).toBe('tokenType accessToken');
+    });
+  });
+
+  describe('given the refresh token API is fetched failed', () => {
+    const mockError500: AxiosError<unknown> = {
+      isAxiosError: true,
+      name: '',
+      message: '',
+      toJSON: () => ({}),
+      config: {
+        headers: axiosHeaders,
+      },
+      response: {
+        data: {
+          errors: [],
+        },
+        status: 500,
+        statusText: 'OK',
+        headers: {},
+        config: {
+          headers: axiosHeaders,
+        },
+      },
+    };
+
+    beforeEach(() => {
+      (authenticationRefreshToken as jest.Mock).mockRejectedValue(() => mockError500);
+      (clearToken as jest.Mock).mockImplementation(() => undefined);
+      (getToken as jest.Mock).mockImplementation(() => ({
+        id: 'resourceId',
+        type: 'resourceType',
+        accessToken: 'accessToken',
+        refreshToken: 'refreshToken',
+        tokenType: 'tokenType',
+      }));
+
+      global.window = Object.create(window);
+      const url = 'http://dummy.com';
+      Object.defineProperty(window, 'location', {
+        value: {
+          href: url,
+        },
+        writable: true,
+      });
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('calls clearToken and redirect the location to sign in', async () => {
+      const mockError: AxiosError<unknown> = {
+        isAxiosError: true,
+        name: '',
+        message: '',
+        toJSON: () => ({}),
+        config: {
+          headers: axiosHeaders,
+        },
+        response: {
+          data: {
+            errors: [],
+          },
+          status: 401,
+          statusText: 'OK',
+          headers: {},
+          config: {
+            headers: axiosHeaders,
+          },
+        },
+      };
+
+      await refreshToken(mockError);
+
+      expect(clearToken).toHaveBeenCalled();
+
+      expect(window.location.href).toBe(paths.signIn);
+    });
+  });
+});

--- a/src/services/refreshToken.test.ts
+++ b/src/services/refreshToken.test.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker';
 import { AxiosError } from 'axios';
 
 import { refreshToken as authenticationRefreshToken } from 'adapters/Authentication';
@@ -14,17 +15,20 @@ jest.mock('axios', () => jest.fn(() => Promise.resolve()));
 const axiosHeaders = new (jest.requireActual('axios').AxiosHeaders)();
 
 describe('refreshToken', () => {
+  const tokenType = faker.string.sample();
+  const accessToken = faker.string.sample();
+
   describe('given the refresh token API is fetched successfully', () => {
     beforeEach(() => {
       (authenticationRefreshToken as jest.Mock).mockImplementation(() =>
         Promise.resolve({
           data: {
-            id: 'id',
+            id: faker.string.uuid(),
             type: 'type',
             attributes: {
-              accessToken: 'access token',
-              tokenType: 'token type',
-              refreshToken: 'refresh token',
+              accessToken: faker.string.sample(),
+              tokenType: faker.string.sample(),
+              refreshToken: faker.string.sample(),
             },
           },
           status: 200,
@@ -33,12 +37,13 @@ describe('refreshToken', () => {
           config: {},
         })
       );
+
       (getToken as jest.Mock).mockImplementation(() => ({
-        id: 'resourceId',
+        id: faker.string.uuid(),
         type: 'resourceType',
-        accessToken: 'accessToken',
-        refreshToken: 'refreshToken',
-        tokenType: 'tokenType',
+        accessToken: accessToken,
+        refreshToken: faker.string.sample(),
+        tokenType: tokenType,
       }));
 
       (setToken as jest.Mock).mockImplementation(() => undefined);
@@ -74,11 +79,11 @@ describe('refreshToken', () => {
 
       await refreshToken(mockError);
 
-      expect(mockError.config?.headers.Authorization).toBe('tokenType accessToken');
+      expect(mockError.config?.headers.Authorization).toBe(`${tokenType} ${accessToken}`);
     });
   });
 
-  describe('given the refresh token API is fetched failed', () => {
+  describe('given the refresh token API fetching is failed', () => {
     const mockError500: AxiosError<unknown> = {
       isAxiosError: true,
       name: '',
@@ -104,11 +109,11 @@ describe('refreshToken', () => {
       (authenticationRefreshToken as jest.Mock).mockRejectedValue(() => mockError500);
       (clearToken as jest.Mock).mockImplementation(() => undefined);
       (getToken as jest.Mock).mockImplementation(() => ({
-        id: 'resourceId',
+        id: faker.string.uuid(),
         type: 'resourceType',
-        accessToken: 'accessToken',
-        refreshToken: 'refreshToken',
-        tokenType: 'tokenType',
+        accessToken: accessToken,
+        refreshToken: faker.string.sample(),
+        tokenType: tokenType,
       }));
 
       global.window ??= Object.create(window);

--- a/src/services/refreshToken.ts
+++ b/src/services/refreshToken.ts
@@ -5,7 +5,7 @@ import { authenticatedHeader } from 'adapters/BaseAuth';
 import { clearToken, getToken, setToken } from 'helpers/authentication';
 import { DeserializableResponse, deserialize } from 'helpers/deserializer';
 import { paths } from 'routes';
-import { SignIn } from 'types/signIn';
+import { Token } from 'types/token';
 
 let isAlreadyFetchingAccessToken = false;
 let subscribers: { (isFetchSuccess: boolean): void }[] = [];
@@ -21,9 +21,9 @@ function addSubscriber(callback: { (isFetchSuccess: boolean): void }) {
 const doRefreshToken = (token: string) => {
   return authenticationRefreshToken(token)
     .then((response: DeserializableResponse) => {
-      const signInType = deserialize<SignIn>(response.data);
+      const tokenType = deserialize<Token>(response.data);
 
-      setToken(signInType);
+      setToken(tokenType);
       return true;
     })
     .catch(() => {
@@ -55,9 +55,9 @@ export const refreshToken = (error: AxiosError<unknown>): Promise<unknown> => {
 
   if (!isAlreadyFetchingAccessToken) {
     isAlreadyFetchingAccessToken = true;
-    const signInToken = getToken();
-    if (signInToken?.refreshToken) {
-      doRefreshToken(signInToken.refreshToken).then((isFetchSuccess) => {
+    const token = getToken();
+    if (token?.refreshToken) {
+      doRefreshToken(token.refreshToken).then((isFetchSuccess) => {
         isAlreadyFetchingAccessToken = false;
         onAccessTokenFetched(isFetchSuccess);
       });

--- a/src/services/refreshToken.ts
+++ b/src/services/refreshToken.ts
@@ -18,12 +18,12 @@ function addSubscriber(callback: { (isFetchSuccess: boolean): void }) {
   subscribers.push(callback);
 }
 
-const doRefreshToken = (token: string) => {
-  return authenticationRefreshToken(token)
+const doRefreshToken = (refreshToken: string) => {
+  return authenticationRefreshToken(refreshToken)
     .then((response: DeserializableResponse) => {
-      const tokenType = deserialize<Token>(response.data);
+      const token = deserialize<Token>(response.data);
 
-      setToken(tokenType);
+      setToken(token);
       return true;
     })
     .catch(() => {
@@ -45,7 +45,6 @@ export const refreshToken = (error: AxiosError<unknown>): Promise<unknown> => {
       }
       if (originalRequest) {
         Object.assign(originalRequest.headers, {
-          ...originalRequest.headers,
           ...authenticatedHeader(),
         });
         resolve(axios(originalRequest));
@@ -56,6 +55,7 @@ export const refreshToken = (error: AxiosError<unknown>): Promise<unknown> => {
   if (!isAlreadyFetchingAccessToken) {
     isAlreadyFetchingAccessToken = true;
     const token = getToken();
+
     if (token?.refreshToken) {
       doRefreshToken(token.refreshToken).then((isFetchSuccess) => {
         isAlreadyFetchingAccessToken = false;

--- a/src/services/refreshToken.ts
+++ b/src/services/refreshToken.ts
@@ -1,0 +1,68 @@
+import axios, { AxiosError } from 'axios';
+
+import { refreshToken as authenticationRefreshToken } from 'adapters/Authentication';
+import { authenticatedHeader } from 'adapters/BaseAuth';
+import { clearToken, getToken, setToken } from 'helpers/authentication';
+import { DeserializableResponse, deserialize } from 'helpers/deserializer';
+import { paths } from 'routes';
+import { SignIn } from 'types/signIn';
+
+let isAlreadyFetchingAccessToken = false;
+let subscribers: { (isFetchSuccess: boolean): void }[] = [];
+
+function onAccessTokenFetched(isFetchSuccess: boolean) {
+  subscribers = subscribers.filter((callback) => callback(isFetchSuccess));
+}
+
+function addSubscriber(callback: { (isFetchSuccess: boolean): void }) {
+  subscribers.push(callback);
+}
+
+const doRefreshToken = (token: string) => {
+  return authenticationRefreshToken(token)
+    .then((response: DeserializableResponse) => {
+      const signInType = deserialize<SignIn>(response.data);
+
+      setToken(signInType);
+      return true;
+    })
+    .catch(() => {
+      clearToken();
+
+      // Redirect to Sign In screen
+      window.location.href = paths.signIn;
+      return false;
+    });
+};
+
+export const refreshToken = (error: AxiosError<unknown>): Promise<unknown> => {
+  const { config: originalRequest } = error;
+  const retryOriginalRequest = new Promise((resolve) => {
+    addSubscriber((isFetchSuccess) => {
+      if (!isFetchSuccess) {
+        resolve({});
+        return;
+      }
+      if (originalRequest) {
+        Object.assign(originalRequest.headers, {
+          ...originalRequest.headers,
+          ...authenticatedHeader(),
+        });
+        resolve(axios(originalRequest));
+      }
+    });
+  });
+
+  if (!isAlreadyFetchingAccessToken) {
+    isAlreadyFetchingAccessToken = true;
+    const signInToken = getToken();
+    if (signInToken?.refreshToken) {
+      doRefreshToken(signInToken.refreshToken).then((isFetchSuccess) => {
+        isAlreadyFetchingAccessToken = false;
+        onAccessTokenFetched(isFetchSuccess);
+      });
+    }
+  }
+
+  return retryOriginalRequest;
+};


### PR DESCRIPTION
Close #17 

## What happened 👀

- When the API returns 401 error code, we call the API `refresh token`.
- If the API is called successfully, it retries the failed API.
- If the API is called unsuccessfully, it clears the token and redirects the user to sign in page.

## Insight 📝

N/A

## Proof Of Work 📹

**Success**:
![Screenshot 2023-07-07 at 09 46 12](https://github.com/manh-t/react-survey/assets/60863885/152e4ce7-6157-4321-8716-5e19c1d063a2)

**Fail**:

https://github.com/manh-t/react-survey/assets/60863885/f6804a25-715e-466c-aa5e-c8f48235f499


