### PR TITLE
[#20] [Integrate] As a user, I can see the survey detail page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-redux": "8.1.0",
         "react-router-dom": "6.3.0",
         "react-scripts": "5.0.1",
+        "react-toastify": "9.1.3",
         "sass": "1.49.11"
       },
       "devDependencies": {
@@ -8279,6 +8280,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -21712,6 +21721,18 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/react-toastify": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.3.tgz",
+      "integrity": "sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-redux": "8.1.0",
     "react-router-dom": "6.3.0",
     "react-scripts": "5.0.1",
+    "react-toastify": "9.1.3",
     "sass": "1.49.11"
   },
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,22 @@
 import React from 'react';
 import { useRoutes } from 'react-router-dom';
-
 import 'dummy.scss';
 import 'assets/stylesheets/application.scss';
+import { ToastContainer } from 'react-toastify';
 
 import routes from './routes';
+
+import 'react-toastify/dist/ReactToastify.css';
 
 const App = (): JSX.Element => {
   const appRoutes = useRoutes(routes);
 
-  return <>{appRoutes}</>;
+  return (
+    <>
+      <ToastContainer />
+      {appRoutes}
+    </>
+  );
 };
 
 export default App;

--- a/src/helpers/deserializer.test.ts
+++ b/src/helpers/deserializer.test.ts
@@ -1,7 +1,7 @@
 import {
-  questionFabricator,
-  surveyWithRelationshipFabricator,
-  surveyWithoutRelationshipFabricator,
+  questionResponseFabricator,
+  surveyResponseWithRelationshipFabricator,
+  surveyResponseWithoutRelationshipFabricator,
   testTypeAge,
   testTypeFabricator,
   testTypeName,
@@ -18,9 +18,9 @@ describe('Deserializer helper', () => {
   }
 
   describe('deserialize', () => {
-    const surveyWithRelationship: Deserializer = surveyWithRelationshipFabricator();
-    const surveyWithoutRelationship: Deserializer = surveyWithoutRelationshipFabricator();
-    const questions: Deserializer[] = questionFabricator.times(1);
+    const surveyWithRelationship: Deserializer = surveyResponseWithRelationshipFabricator();
+    const surveyWithoutRelationship: Deserializer = surveyResponseWithoutRelationshipFabricator();
+    const questions: Deserializer[] = questionResponseFabricator.times(1);
 
     it('returns deserialized data', () => {
       const deserializedData = deserialize<TestType>(testTypeFabricator());

--- a/src/screens/Survey/index.test.tsx
+++ b/src/screens/Survey/index.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { faker } from '@faker-js/faker';
 import { render, screen } from '@testing-library/react';
 
 import { mainViewTestIds } from 'components/MainView';
@@ -25,11 +26,11 @@ describe('SurveyScreen', () => {
   const mockState: { survey: SurveyState } = {
     survey: {
       survey: {
-        id: 'd5de6a8f8f5f1cfe51bc',
+        id: faker.string.uuid(),
         resourceType: 'survey',
-        title: 'Scarlett Bangkok',
-        description: "We'd love ot hear from you!",
-        coverImageUrl: 'https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_',
+        title: faker.string.sample(),
+        description: faker.string.sample(),
+        coverImageUrl: faker.image.url(),
       },
       isLoading: true,
       isError: false,

--- a/src/screens/Survey/index.test.tsx
+++ b/src/screens/Survey/index.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import { faker } from '@faker-js/faker';
 import { render, screen } from '@testing-library/react';
 
 import { mainViewTestIds } from 'components/MainView';
 import { useAppDispatch, useAppSelector } from 'hooks';
 import { SurveyState } from 'store/reducers/Survey';
+import { surveyStateFabricator } from 'tests/fabricator';
 import TestWrapper from 'tests/TestWrapper';
 
 import SurveyScreen, { surveyScreenTestIds } from '.';
@@ -15,6 +15,19 @@ const mockDispatch = jest.fn();
 jest.mock('hooks');
 
 describe('SurveyScreen', () => {
+  const mockState: { survey: SurveyState } = {
+    survey: surveyStateFabricator(),
+  };
+
+  beforeEach(() => {
+    (useAppSelector as jest.Mock).mockImplementation((callback) => callback(mockState));
+    (useAppDispatch as jest.Mock).mockImplementation(() => mockDispatch);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   const TestComponent = (): JSX.Element => {
     return (
       <TestWrapper>
@@ -22,30 +35,6 @@ describe('SurveyScreen', () => {
       </TestWrapper>
     );
   };
-
-  const mockState: { survey: SurveyState } = {
-    survey: {
-      survey: {
-        id: faker.string.uuid(),
-        resourceType: 'survey',
-        title: faker.string.sample(),
-        description: faker.string.sample(),
-        coverImageUrl: faker.image.url(),
-      },
-      isLoading: true,
-      isError: false,
-    },
-  };
-
-  beforeEach(() => {
-    (useAppSelector as jest.Mock).mockImplementation((callback) => callback(mockState));
-    (useAppDispatch as jest.Mock).mockImplementation(() => mockDispatch);
-    jest.spyOn(React, 'useEffect').mockImplementation(() => jest.fn());
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
 
   describe('given the isLoading is true', () => {
     it('shows the loading indicator', () => {
@@ -70,6 +59,7 @@ describe('SurveyScreen', () => {
 
     it('renders Survey screen and its components', () => {
       render(<TestComponent />);
+
       const mainView = screen.getByTestId(mainViewTestIds.base);
       const backButton = screen.getByTestId(surveyScreenTestIds.backButton);
       const coverImage = screen.getByTestId(surveyScreenTestIds.coverImage);

--- a/src/screens/Survey/index.test.tsx
+++ b/src/screens/Survey/index.test.tsx
@@ -3,9 +3,15 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { mainViewTestIds } from 'components/MainView';
+import { useAppDispatch, useAppSelector } from 'hooks';
+import { SurveyState } from 'store/reducers/Survey';
 import TestWrapper from 'tests/TestWrapper';
 
 import SurveyScreen, { surveyScreenTestIds } from '.';
+
+const mockDispatch = jest.fn();
+
+jest.mock('hooks');
 
 describe('SurveyScreen', () => {
   const TestComponent = (): JSX.Element => {
@@ -16,22 +22,67 @@ describe('SurveyScreen', () => {
     );
   };
 
-  it('renders Survey screen and its components', () => {
-    render(<TestComponent />);
+  const mockState: { survey: SurveyState } = {
+    survey: {
+      survey: {
+        id: 'd5de6a8f8f5f1cfe51bc',
+        resourceType: 'survey',
+        title: 'Scarlett Bangkok',
+        description: "We'd love ot hear from you!",
+        coverImageUrl: 'https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_',
+      },
+      isLoading: true,
+      isError: false,
+    },
+  };
 
-    const backgroundImage = screen.getByTestId(mainViewTestIds.base);
-    const backButton = screen.getByTestId(surveyScreenTestIds.backButton);
-    const coverImage = screen.getByTestId(surveyScreenTestIds.coverImage);
-    const title = screen.getByTestId(surveyScreenTestIds.title);
-    const description = screen.getByTestId(surveyScreenTestIds.description);
-    const startSurveyButton = screen.getByTestId(surveyScreenTestIds.startSurveyButton);
+  beforeEach(() => {
+    (useAppSelector as jest.Mock).mockImplementation((callback) => callback(mockState));
+    (useAppDispatch as jest.Mock).mockImplementation(() => mockDispatch);
+    jest.spyOn(React, 'useEffect').mockImplementation(() => jest.fn());
+  });
 
-    expect(backgroundImage).toBeVisible();
-    expect(backButton).toBeVisible();
-    expect(coverImage).toBeVisible();
-    expect(title).toBeVisible();
-    expect(description).toBeVisible();
-    expect(startSurveyButton).toBeVisible();
-    expect(startSurveyButton).toHaveTextContent('Start Survey');
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('given the isLoading is true', () => {
+    it('shows the loading indicator', () => {
+      render(<TestComponent />);
+
+      const loadingDialogComponent = screen.getByTestId(surveyScreenTestIds.loadingDialog);
+
+      expect(loadingDialogComponent).toBeVisible();
+    });
+  });
+
+  describe('given the isLoading is false', () => {
+    beforeEach(() => {
+      mockState.survey.isLoading = false;
+    });
+
+    it('does NOT show the loading indicator', () => {
+      render(<TestComponent />);
+
+      expect(screen.queryByTestId(surveyScreenTestIds.loadingDialog)).not.toBeInTheDocument();
+    });
+
+    it('renders Survey screen and its components', () => {
+      render(<TestComponent />);
+      const mainView = screen.getByTestId(mainViewTestIds.base);
+      const backButton = screen.getByTestId(surveyScreenTestIds.backButton);
+      const coverImage = screen.getByTestId(surveyScreenTestIds.coverImage);
+      const title = screen.getByTestId(surveyScreenTestIds.title);
+      const description = screen.getByTestId(surveyScreenTestIds.description);
+      const startSurveyButton = screen.getByTestId(surveyScreenTestIds.startSurveyButton);
+
+      expect(mainView).toBeVisible();
+      expect(backButton).toBeVisible();
+      expect(coverImage).toBeVisible();
+      expect(title).toBeVisible();
+      expect(description).toBeVisible();
+      expect(startSurveyButton).toBeVisible();
+      expect(startSurveyButton).toHaveTextContent('Start Survey');
+    });
   });
 });

--- a/src/screens/Survey/index.tsx
+++ b/src/screens/Survey/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 
 import { ReactComponent as ArrowBack } from 'assets/images/icons/arrow-back.svg';
 import ElevatedButton from 'components/ElevatedButton';
@@ -8,8 +8,6 @@ import LoadingDialog from 'components/LoadingDialog';
 import MainView from 'components/MainView';
 import { useAppDispatch, useAppSelector } from 'hooks';
 import { getSurveyAsyncThunk } from 'store/reducers/Survey';
-
-import 'react-toastify/dist/ReactToastify.css';
 
 export const surveyScreenTestIds = {
   backButton: 'survey__back-button',
@@ -44,47 +42,44 @@ const SurveyScreen = (): JSX.Element => {
   }, [isError]);
 
   return (
-    <div>
-      <ToastContainer />
-      <MainView backgroundUrl={isLoading ? undefined : survey?.coverImageUrl}>
-        {isLoading || isError ? (
-          <div></div>
-        ) : (
-          <div className="flex flex-col">
-            <button
-              className="w-fit mt-[37px] ml-[39px] p-1 text-white"
-              onClick={goBack}
-              data-test-id={surveyScreenTestIds.backButton}
+    <MainView backgroundUrl={isLoading ? undefined : survey?.coverImageUrl}>
+      {isLoading || isError ? (
+        <div></div>
+      ) : (
+        <div className="flex flex-col">
+          <button
+            className="w-fit mt-[37px] ml-[39px] p-1 text-white"
+            onClick={goBack}
+            data-test-id={surveyScreenTestIds.backButton}
+          >
+            <ArrowBack />
+          </button>
+          <div className="w-1/2 self-center pt-36">
+            <img
+              src={survey?.coverImageUrl ? `${survey?.coverImageUrl}l` : ''}
+              className="w-full h-[302px] rounded-[12px] object-cover"
+              alt="survey"
+              data-test-id={surveyScreenTestIds.coverImage}
+            />
+            <p className="text-white text-x-large font-extrabold pt-8" data-test-id={surveyScreenTestIds.title}>
+              {survey?.title}
+            </p>
+            <p
+              className="text-white text-regular tracking-survey-tight opacity-60 pt-2"
+              data-test-id={surveyScreenTestIds.description}
             >
-              <ArrowBack />
-            </button>
-            <div className="w-1/2 self-center pt-36">
-              <img
-                src={survey?.coverImageUrl ? `${survey?.coverImageUrl}l` : ''}
-                className="w-full h-[302px] rounded-[12px] object-cover"
-                alt="survey"
-                data-test-id={surveyScreenTestIds.coverImage}
-              />
-              <p className="text-white text-x-large font-extrabold pt-8" data-test-id={surveyScreenTestIds.title}>
-                {survey?.title}
-              </p>
-              <p
-                className="text-white text-regular tracking-survey-tight opacity-60 pt-2"
-                data-test-id={surveyScreenTestIds.description}
-              >
-                {survey?.description}
-              </p>
-              <div className="pt-8">
-                <ElevatedButton isFullWidth type="submit" data-test-id={surveyScreenTestIds.startSurveyButton}>
-                  Start Survey
-                </ElevatedButton>
-              </div>
+              {survey?.description}
+            </p>
+            <div className="pt-8">
+              <ElevatedButton isFullWidth type="submit" data-test-id={surveyScreenTestIds.startSurveyButton}>
+                Start Survey
+              </ElevatedButton>
             </div>
           </div>
-        )}
-        {isLoading && <LoadingDialog data-test-id={surveyScreenTestIds.loadingDialog} />}
-      </MainView>
-    </div>
+        </div>
+      )}
+      {isLoading && <LoadingDialog data-test-id={surveyScreenTestIds.loadingDialog} />}
+    </MainView>
   );
 };
 

--- a/src/screens/Survey/index.tsx
+++ b/src/screens/Survey/index.tsx
@@ -1,8 +1,15 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { ToastContainer, toast } from 'react-toastify';
 
 import { ReactComponent as ArrowBack } from 'assets/images/icons/arrow-back.svg';
 import ElevatedButton from 'components/ElevatedButton';
+import LoadingDialog from 'components/LoadingDialog';
 import MainView from 'components/MainView';
+import { useAppDispatch, useAppSelector } from 'hooks';
+import { getSurveyAsyncThunk } from 'store/reducers/Survey';
+
+import 'react-toastify/dist/ReactToastify.css';
 
 export const surveyScreenTestIds = {
   backButton: 'survey__back-button',
@@ -10,39 +17,74 @@ export const surveyScreenTestIds = {
   title: 'survey__title-text',
   description: 'survey__description-text',
   startSurveyButton: 'survey__start-survey-button',
+  loadingDialog: 'survey__loading-dialog',
+  toast: 'survey__toast',
 };
 
 const SurveyScreen = (): JSX.Element => {
+  const { id } = useParams();
+
+  const { survey, isLoading, isError } = useAppSelector((state) => state.survey);
+
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  function goBack() {
+    navigate(-1);
+  }
+
+  useEffect(() => {
+    dispatch(getSurveyAsyncThunk(id ?? ''));
+  }, [dispatch, id]);
+
+  useEffect(() => {
+    if (isError) {
+      toast.error('There is something wrong. Please try again later!', { position: 'top-center' });
+    }
+  }, [isError]);
+
   return (
-    <MainView backgroundUrl="https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_">
-      <div className="flex flex-col">
-        <button type="button" className="w-fit mt-[37px] ml-[39px] p-1 text-white" data-test-id={surveyScreenTestIds.backButton}>
-          <ArrowBack />
-        </button>
-        <div className="w-1/2 self-center pt-36">
-          <img
-            src="https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_l"
-            className="w-full h-[302px] rounded-[12px] object-cover"
-            alt="survey"
-            data-test-id={surveyScreenTestIds.coverImage}
-          />
-          <p className="text-white text-x-large font-extrabold pt-8" data-test-id={surveyScreenTestIds.title}>
-            Working from home Check-In
-          </p>
-          <p
-            className="text-white text-regular tracking-survey-tight opacity-60 pt-2"
-            data-test-id={surveyScreenTestIds.description}
-          >
-            We would like to know how you feel about our work from home (WFH) experience.
-          </p>
-          <div className="pt-8">
-            <ElevatedButton isFullWidth type="submit" data-test-id={surveyScreenTestIds.startSurveyButton}>
-              Start Survey
-            </ElevatedButton>
+    <div>
+      <ToastContainer />
+      <MainView backgroundUrl={isLoading ? undefined : survey?.coverImageUrl}>
+        {isLoading || isError ? (
+          <div></div>
+        ) : (
+          <div className="flex flex-col">
+            <button
+              className="w-fit mt-[37px] ml-[39px] p-1 text-white"
+              onClick={goBack}
+              data-test-id={surveyScreenTestIds.backButton}
+            >
+              <ArrowBack />
+            </button>
+            <div className="w-1/2 self-center pt-36">
+              <img
+                src={survey?.coverImageUrl ? `${survey?.coverImageUrl}l` : ''}
+                className="w-full h-[302px] rounded-[12px] object-cover"
+                alt="survey"
+                data-test-id={surveyScreenTestIds.coverImage}
+              />
+              <p className="text-white text-x-large font-extrabold pt-8" data-test-id={surveyScreenTestIds.title}>
+                {survey?.title}
+              </p>
+              <p
+                className="text-white text-regular tracking-survey-tight opacity-60 pt-2"
+                data-test-id={surveyScreenTestIds.description}
+              >
+                {survey?.description}
+              </p>
+              <div className="pt-8">
+                <ElevatedButton isFullWidth type="submit" data-test-id={surveyScreenTestIds.startSurveyButton}>
+                  Start Survey
+                </ElevatedButton>
+              </div>
+            </div>
           </div>
-        </div>
-      </div>
-    </MainView>
+        )}
+        {isLoading && <LoadingDialog data-test-id={surveyScreenTestIds.loadingDialog} />}
+      </MainView>
+    </div>
   );
 };
 

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -1,6 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit';
 
 import { authSlice } from './reducers/Authentication';
+import { surveySlice } from './reducers/Survey';
 import { surveysSlice } from './reducers/Surveys';
 import { userSlice } from './reducers/User';
 
@@ -8,6 +9,7 @@ export const reducers = {
   auth: authSlice.reducer,
   surveys: surveysSlice.reducer,
   user: userSlice.reducer,
+  survey: surveySlice.reducer,
 };
 
 export const store = configureStore({

--- a/src/store/reducers/Survey/action.ts
+++ b/src/store/reducers/Survey/action.ts
@@ -1,0 +1,14 @@
+import { AsyncThunkPayloadCreator } from '@reduxjs/toolkit';
+
+import { getSurvey } from 'adapters/Survey';
+import { DeserializableResponse, deserialize } from 'helpers/deserializer';
+import { JSONObject } from 'helpers/json';
+import { Survey } from 'types/survey';
+
+export const getSurveyThunkCreator: AsyncThunkPayloadCreator<Survey, string, JSONObject> = async (surveyId: string) => {
+  return getSurvey(surveyId).then((response: DeserializableResponse) => {
+    const survey = deserialize<Survey>(response.data, response.included);
+
+    return survey;
+  });
+};

--- a/src/store/reducers/Survey/action.ts
+++ b/src/store/reducers/Survey/action.ts
@@ -6,9 +6,5 @@ import { JSONObject } from 'helpers/json';
 import { Survey } from 'types/survey';
 
 export const getSurveyThunkCreator: AsyncThunkPayloadCreator<Survey, string, JSONObject> = async (surveyId: string) => {
-  return getSurvey(surveyId).then((response: DeserializableResponse) => {
-    const survey = deserialize<Survey>(response.data, response.included);
-
-    return survey;
-  });
+  return getSurvey(surveyId).then((response: DeserializableResponse) => deserialize<Survey>(response.data, response.included));
 };

--- a/src/store/reducers/Survey/index.test.ts
+++ b/src/store/reducers/Survey/index.test.ts
@@ -1,0 +1,103 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { AxiosResponse } from 'axios';
+
+import { getSurvey } from 'adapters/Survey';
+
+import { getSurveyAsyncThunk, surveySlice } from '.';
+
+jest.mock('adapters/Survey');
+
+describe('survey slice', () => {
+  describe('getSurveyAsyncThunk', () => {
+    const successResponse = {
+      data: {
+        id: 'd5de6a8f8f5f1cfe51bc',
+        type: 'survey',
+        attributes: {
+          title: 'Scarlett Bangkok',
+          description: "We'd love ot hear from you!",
+          coverImageUrl: 'https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_',
+        },
+      },
+    };
+
+    it('calls getSurvey API successfully', async () => {
+      (getSurvey as jest.Mock).mockResolvedValue(successResponse as AxiosResponse);
+      const dispatch = jest.fn();
+
+      const input = 'survey id';
+
+      const getSurveyFunction = getSurveyAsyncThunk(input);
+
+      const getSurveyPayload = await getSurveyFunction(dispatch, () => {}, undefined);
+
+      const expectedResult = {
+        id: 'd5de6a8f8f5f1cfe51bc',
+        resourceType: 'survey',
+        title: 'Scarlett Bangkok',
+        description: "We'd love ot hear from you!",
+        coverImageUrl: 'https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_',
+      };
+
+      expect(getSurveyPayload.meta.arg).toBe(input);
+      expect(getSurveyPayload.payload).toEqual(expectedResult);
+
+      expect(dispatch).toHaveBeenNthCalledWith(1, getSurveyAsyncThunk.pending(getSurveyPayload.meta.requestId, input));
+      expect(dispatch).toHaveBeenNthCalledWith(
+        2,
+        getSurveyAsyncThunk.fulfilled(expectedResult, getSurveyPayload.meta.requestId, input)
+      );
+    });
+  });
+
+  describe('extraReducers', () => {
+    const mockEmptyState = {
+      isLoading: true,
+      isError: false,
+    };
+
+    describe('getSurveyAsyncThunk.pending', () => {
+      it('returns no survey', async () => {
+        const dispatchedState = surveySlice.reducer(mockEmptyState, {
+          type: 'survey/getSurvey/pending',
+        });
+
+        expect(dispatchedState.isLoading).toBe(true);
+        expect(dispatchedState.survey).toBeUndefined();
+        expect(dispatchedState.isError).toBe(false);
+      });
+    });
+
+    describe('getSurveyAsyncThunk.fulfilled', () => {
+      it('returns the survey', async () => {
+        const expectedResult = {
+          id: 'd5de6a8f8f5f1cfe51bc',
+          resourceType: 'survey',
+          title: 'Scarlett Bangkok',
+          description: "We'd love ot hear from you!",
+          coverImageUrl: 'https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_',
+        };
+        const dispatchedState = surveySlice.reducer(mockEmptyState, {
+          type: 'survey/getSurvey/fulfilled',
+          payload: expectedResult,
+        });
+
+        expect(dispatchedState.isLoading).toBe(false);
+        expect(dispatchedState.isError).toBe(false);
+        expect(dispatchedState.survey).toBe(expectedResult);
+      });
+    });
+
+    describe('getSurveyAsyncThunk.rejected', () => {
+      it('returns no survey', async () => {
+        const dispatchedState = surveySlice.reducer(mockEmptyState, {
+          type: 'survey/getSurvey/rejected',
+        });
+
+        expect(dispatchedState.isLoading).toBe(false);
+        expect(dispatchedState.isError).toBe(true);
+        expect(dispatchedState.survey).toBeUndefined();
+      });
+    });
+  });
+});

--- a/src/store/reducers/Survey/index.test.ts
+++ b/src/store/reducers/Survey/index.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
+import { faker } from '@faker-js/faker';
 import { AxiosResponse } from 'axios';
 
 import { getSurvey } from 'adapters/Survey';
@@ -8,21 +9,33 @@ import { getSurveyAsyncThunk, surveySlice } from '.';
 jest.mock('adapters/Survey');
 
 describe('survey slice', () => {
-  describe('getSurveyAsyncThunk', () => {
-    const successResponse = {
-      data: {
-        id: 'd5de6a8f8f5f1cfe51bc',
-        type: 'survey',
-        attributes: {
-          title: 'Scarlett Bangkok',
-          description: "We'd love ot hear from you!",
-          coverImageUrl: 'https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_',
-        },
+  const id = faker.string.uuid();
+  const title = faker.string.sample();
+  const description = faker.string.sample();
+  const coverImageUrl = faker.image.url();
+  const surveyResponse = {
+    data: {
+      id: id,
+      type: 'survey',
+      attributes: {
+        title: title,
+        description: description,
+        coverImageUrl: coverImageUrl,
       },
-    };
+    },
+  };
 
+  const survey = {
+    id: id,
+    resourceType: 'survey',
+    title: title,
+    description: description,
+    coverImageUrl: coverImageUrl,
+  };
+
+  describe('getSurveyAsyncThunk', () => {
     it('calls getSurvey API successfully', async () => {
-      (getSurvey as jest.Mock).mockResolvedValue(successResponse as AxiosResponse);
+      (getSurvey as jest.Mock).mockResolvedValue(surveyResponse as AxiosResponse);
       const dispatch = jest.fn();
 
       const input = 'survey id';
@@ -31,22 +44,11 @@ describe('survey slice', () => {
 
       const getSurveyPayload = await getSurveyFunction(dispatch, () => {}, undefined);
 
-      const expectedResult = {
-        id: 'd5de6a8f8f5f1cfe51bc',
-        resourceType: 'survey',
-        title: 'Scarlett Bangkok',
-        description: "We'd love ot hear from you!",
-        coverImageUrl: 'https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_',
-      };
-
       expect(getSurveyPayload.meta.arg).toBe(input);
-      expect(getSurveyPayload.payload).toEqual(expectedResult);
+      expect(getSurveyPayload.payload).toEqual(survey);
 
       expect(dispatch).toHaveBeenNthCalledWith(1, getSurveyAsyncThunk.pending(getSurveyPayload.meta.requestId, input));
-      expect(dispatch).toHaveBeenNthCalledWith(
-        2,
-        getSurveyAsyncThunk.fulfilled(expectedResult, getSurveyPayload.meta.requestId, input)
-      );
+      expect(dispatch).toHaveBeenNthCalledWith(2, getSurveyAsyncThunk.fulfilled(survey, getSurveyPayload.meta.requestId, input));
     });
   });
 
@@ -70,21 +72,14 @@ describe('survey slice', () => {
 
     describe('getSurveyAsyncThunk.fulfilled', () => {
       it('returns the survey', async () => {
-        const expectedResult = {
-          id: 'd5de6a8f8f5f1cfe51bc',
-          resourceType: 'survey',
-          title: 'Scarlett Bangkok',
-          description: "We'd love ot hear from you!",
-          coverImageUrl: 'https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_',
-        };
         const dispatchedState = surveySlice.reducer(mockEmptyState, {
           type: 'survey/getSurvey/fulfilled',
-          payload: expectedResult,
+          payload: survey,
         });
 
         expect(dispatchedState.isLoading).toBe(false);
         expect(dispatchedState.isError).toBe(false);
-        expect(dispatchedState.survey).toBe(expectedResult);
+        expect(dispatchedState.survey).toBe(survey);
       });
     });
 

--- a/src/store/reducers/Survey/index.ts
+++ b/src/store/reducers/Survey/index.ts
@@ -1,0 +1,41 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+
+import { Survey } from 'types/survey';
+
+import { getSurveyThunkCreator } from './action';
+
+export interface SurveyState {
+  survey?: Survey;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+export const initialState: SurveyState = {
+  isLoading: true,
+  isError: false,
+};
+
+export const getSurveyAsyncThunk = createAsyncThunk('survey/getSurvey', getSurveyThunkCreator);
+
+export const surveySlice = createSlice({
+  name: 'survey',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(getSurveyAsyncThunk.pending, (state) => {
+      state.isLoading = true;
+      state.isError = false;
+    });
+    builder.addCase(getSurveyAsyncThunk.fulfilled, (state, action) => {
+      state.isLoading = false;
+      state.isError = false;
+      state.survey = action.payload;
+    });
+    builder.addCase(getSurveyAsyncThunk.rejected, (state) => {
+      state.isLoading = false;
+      state.isError = true;
+    });
+  },
+});
+
+export const surveyAction = surveySlice.actions;

--- a/src/tests/fabricator.ts
+++ b/src/tests/fabricator.ts
@@ -12,10 +12,10 @@ export const testTypeFabricator = Fabricator({
   },
 });
 
-// Survey
+// Responses
 const questionId = faker.string.uuid();
 
-export const surveyWithRelationshipFabricator = Fabricator({
+export const surveyResponseWithRelationshipFabricator = Fabricator({
   type: 'survey',
   id: faker.string.uuid(),
   attributes: {
@@ -35,7 +35,7 @@ export const surveyWithRelationshipFabricator = Fabricator({
   },
 });
 
-export const surveyWithoutRelationshipFabricator = Fabricator({
+export const surveyResponseWithoutRelationshipFabricator = Fabricator({
   type: 'survey',
   id: faker.string.uuid(),
   attributes: {
@@ -50,7 +50,7 @@ export const surveyWithoutRelationshipFabricator = Fabricator({
   },
 });
 
-export const questionFabricator = Fabricator({
+export const questionResponseFabricator = Fabricator({
   type: 'question',
   id: questionId,
   attributes: {
@@ -67,4 +67,20 @@ export const questionFabricator = Fabricator({
     isShareableOnTwitter: false,
     tagList: '',
   },
+});
+
+// Models
+export const surveyFabricator = Fabricator({
+  id: faker.string.uuid(),
+  resourceType: 'survey',
+  title: faker.string.sample(),
+  description: faker.string.sample(),
+  coverImageUrl: faker.image.url(),
+});
+
+// States
+export const surveyStateFabricator = Fabricator({
+  survey: () => surveyFabricator(),
+  isLoading: true,
+  isError: false,
 });


### PR DESCRIPTION
Close #20 

## What happened 👀

- When the API request is calling, show the loading dialog
- When the API is called successfully, show the survey detail page.
- When the API is called unsuccessfully, show the error toast.

## Insight 📝

- Add `react-toastify` to show the toast.

## Proof Of Work 📹

**Success**
![image](https://github.com/manh-t/react-survey/assets/60863885/863ff57f-ea59-4fe6-9700-f41a403681dd)

**Failed**
![image](https://github.com/manh-t/react-survey/assets/60863885/f4f6e51a-2078-4445-868d-11e03f7d27af)

